### PR TITLE
Add a `with_spawn` method to the fifo struct

### DIFF
--- a/ssip-client-async/examples/spawn_speechd.rs
+++ b/ssip-client-async/examples/spawn_speechd.rs
@@ -1,5 +1,5 @@
 #[cfg(all(unix, not(feature = "async-mio")))]
-use ssip_client_async::{fifo, ClientName, ClientResult, ClientScope, OK_LANGUAGE_SET};
+use ssip_client_async::{fifo, ClientResult};
 
 #[cfg(all(unix, not(feature = "async-mio")))]
 fn main() -> ClientResult<()> {

--- a/ssip-client-async/examples/spawn_speechd.rs
+++ b/ssip-client-async/examples/spawn_speechd.rs
@@ -3,8 +3,7 @@ use ssip_client_async::{fifo, ClientResult};
 
 #[cfg(all(unix, not(feature = "async-mio")))]
 fn main() -> ClientResult<()> {
-
-    // spawn the speech-dispatcher daemon before creating the client 
+    // spawn the speech-dispatcher daemon before creating the client
     // and trying to connect to the speech-dispatcher socket
     let mut client = fifo::Builder::new().with_spawn()?.build()?;
 

--- a/ssip-client-async/examples/spawn_speechd.rs
+++ b/ssip-client-async/examples/spawn_speechd.rs
@@ -1,0 +1,29 @@
+#[cfg(all(unix, not(feature = "async-mio")))]
+use ssip_client_async::{fifo, ClientName, ClientResult, ClientScope, OK_LANGUAGE_SET};
+
+#[cfg(all(unix, not(feature = "async-mio")))]
+fn main() -> ClientResult<()> {
+
+    // spawn the speech-dispatcher daemon before creating the client 
+    // and trying to connect to the speech-dispatcher socket
+    let mut client = fifo::Builder::new().with_spawn()?.build()?;
+
+    client
+        .speak()?
+        .check_receiving_data()?
+        .send_line("test message for the spawn example")?
+        .receive_message_id()?;
+
+    client.quit()?.receive()?;
+    Ok(())
+}
+
+#[cfg(all(unix, feature = "async-mio"))]
+fn main() {
+    println!("see async_mio_loop for an example of asynchronous client.");
+}
+
+#[cfg(not(unix))]
+fn main() {
+    println!("example only available on unix.");
+}

--- a/ssip-client-async/src/fifo.rs
+++ b/ssip-client-async/src/fifo.rs
@@ -98,13 +98,12 @@ mod synchronous {
         pub fn with_spawn(&self) -> io::Result<&Self> {
             Command::new("speech-dispatcher")
                 // respect the speechd `DisableAutoSpawn` setting
-                .args(["--spawn"])  
+                .args(["--spawn"])
                 .output()?;
             Ok(self)
         }
 
         pub fn build(&self) -> io::Result<Client<UnixStream>> {
-
             let input = UnixStream::connect(self.path.get()?)?;
             match self.mode {
                 StreamMode::Blocking => input.set_nonblocking(false)?,


### PR DESCRIPTION
## Change

- Adds a `with_spawn` method on the fifo struct to make sure that the speech-dispatcher daemon is started before trying to initialize the unix socket connection.
    - I named it `with_spawn` since to my understanding `autospawn` is a properly of the server, and `--spawn` is the client command line arg, thus making `with_spawn` more clear to the client API vs `with_autospawn`. 
    - this has to be on the fifo struct before the `build()` method  since `build()` makes a connection to the speechd socket and if speechd is not running properly, it will fail to connect.

- Adds an associated example

## Background

Currently, at least in my testing, speech dispatcher (at least on the Ubuntu 24.04 based systems I have used) will sometimes stop receiving connections or automatically shut itself down after the last client disconnects. If this is the case, then currently as this library is implemented, the client will not  be able to connect.

We can tinker in future PRs and if relevant, add some option to automatically start it similar to the other clients like the one in C/Python/[go](https://github.com/ilyapashuk/go-speechd/blob/55d1c0c643ab504327f61e765e31aa0c45ef5d34/speechd.go#L124) but as of right now I think this API seems reasonable.
- fwiw in the baseline C api docs it also says `autospawn is a boolean flag specifying whether the function should try to autospawn (autostart) the Speech Dispatcher server process if it is not running already. This is set to 1 by default, so this function should normally not fail even if the server is not yet running. `  written [here](https://htmlpreview.github.io/?https://github.com/brailcom/speechd/blob/master/doc/speech-dispatcher.html#Autospawning-1)

Another thing worth calling out, in the go-speechd client _but not in this rust implementation for some reason_ was this https://github.com/ilyapashuk/go-speechd/issues/1, namely `Due to a bug in Speech Dispatcher, it is currently necessary to include a wait statement after the autospawn for about 0.5 seconds before attempting a connection. `
That quote I pasted above is listed on the speech dispatcher docs page at the bottom of this section [here](https://htmlpreview.github.io/?https://github.com/brailcom/speechd/blob/master/doc/speech-dispatcher.html#Autospawning-1)

I am not finding this to be an issue locally but wanted to call that out just in case if it comes up as an issue for others.


