### PR TITLE
Begin automatic language detection support

### DIFF
--- a/ssip-client-async/Cargo.toml
+++ b/ssip-client-async/Cargo.toml
@@ -17,6 +17,7 @@ log = { version = "0.4", features = ["max_level_debug", "release_max_level_info"
 mio = { version = "0.8", optional = true }
 tokio = { version = "1.0", features = ["io-util", "rt", "macros", "net"] }
 async-std = { version = "1.0", default-features = true }
+lingua = "1.7.1"
 
 [features]
 async-mio = ["mio/net", "mio/os-poll"]

--- a/ssip-client-async/examples/automatic_language_detection.rs
+++ b/ssip-client-async/examples/automatic_language_detection.rs
@@ -19,9 +19,7 @@ fn main() -> ClientResult<()> {
         .check_client_name_set()?
         .speak()?
         .check_receiving_data()?
-        .send_lines_multilingual(
-            &"Hello, my name is Joe. меня зовут джо".to_string(),
-        )?;
+        .send_lines_multilingual(&"Hello, my name is Joe. меня зовут джо".to_string())?;
 
     client.quit()?.receive()?;
     Ok(())

--- a/ssip-client-async/examples/automatic_language_detection.rs
+++ b/ssip-client-async/examples/automatic_language_detection.rs
@@ -3,19 +3,25 @@ use ssip_client_async::{fifo, ClientResult};
 
 #[cfg(all(unix, not(feature = "async-mio")))]
 fn main() -> ClientResult<()> {
-    // spawn the speech-dispatcher daemon before creating the client
-    // and trying to connect to the speech-dispatcher socket
-    let languages = vec![lingua::IsoCode639_3::ENG, lingua::IsoCode639_3::SPA];
+    use ssip::ClientName;
+
+    let languages = vec![lingua::IsoCode639_1::EN, lingua::IsoCode639_1::RU];
     let mut client = fifo::Builder::new()
-        .with_language_detection(&languages)
+        // initialize the language detection model with a list of languages to distinguish between
+        .with_automatic_detection_languages(&languages)
+        // spawn the speech-dispatcher daemon before creating the client
+        // and trying to connect to the speech-dispatcher socket
         .with_spawn()?
         .build()?;
 
     client
+        .set_client_name(ClientName::new("sasha", "example_app"))?
+        .check_client_name_set()?
         .speak()?
         .check_receiving_data()?
-        .send_line("test message for the spawn example")?
-        .receive_message_id()?;
+        .send_lines_multilingual(
+            &"Hello, my name is Joe. меня зовут джо".to_string(),
+        )?;
 
     client.quit()?.receive()?;
     Ok(())

--- a/ssip-client-async/examples/automatic_language_detection.rs
+++ b/ssip-client-async/examples/automatic_language_detection.rs
@@ -1,0 +1,29 @@
+#[cfg(all(unix, not(feature = "async-mio")))]
+use ssip_client_async::{fifo, ClientResult};
+
+#[cfg(all(unix, not(feature = "async-mio")))]
+fn main() -> ClientResult<()> {
+    // spawn the speech-dispatcher daemon before creating the client
+    // and trying to connect to the speech-dispatcher socket
+    let languages = vec![lingua::IsoCode639_3::ENG, lingua::IsoCode639_3::SPA];
+    let mut client = fifo::Builder::new().with_language_detection(&languages).with_spawn()?.build()?;
+
+    client
+        .speak()?
+        .check_receiving_data()?
+        .send_line("test message for the spawn example")?
+        .receive_message_id()?;
+
+    client.quit()?.receive()?;
+    Ok(())
+}
+
+#[cfg(all(unix, feature = "async-mio"))]
+fn main() {
+    println!("see async_mio_loop for an example of asynchronous client.");
+}
+
+#[cfg(not(unix))]
+fn main() {
+    println!("example only available on unix.");
+}

--- a/ssip-client-async/examples/automatic_language_detection.rs
+++ b/ssip-client-async/examples/automatic_language_detection.rs
@@ -6,7 +6,10 @@ fn main() -> ClientResult<()> {
     // spawn the speech-dispatcher daemon before creating the client
     // and trying to connect to the speech-dispatcher socket
     let languages = vec![lingua::IsoCode639_3::ENG, lingua::IsoCode639_3::SPA];
-    let mut client = fifo::Builder::new().with_language_detection(&languages).with_spawn()?.build()?;
+    let mut client = fifo::Builder::new()
+        .with_language_detection(&languages)
+        .with_spawn()?
+        .build()?;
 
     client
         .speak()?

--- a/ssip-client-async/examples/automatic_language_detection.rs
+++ b/ssip-client-async/examples/automatic_language_detection.rs
@@ -4,24 +4,36 @@ use ssip_client_async::{fifo, ClientResult};
 #[cfg(all(unix, not(feature = "async-mio")))]
 fn main() -> ClientResult<()> {
     use ssip::ClientName;
-
-    let languages = vec![lingua::IsoCode639_1::EN, lingua::IsoCode639_1::RU];
-    let mut client = fifo::Builder::new()
+    let english_or_russian = vec![lingua::IsoCode639_1::EN, lingua::IsoCode639_1::RU];
+    let mut english_or_russian_client = fifo::Builder::new()
         // initialize the language detection model with a list of languages to distinguish between
-        .with_automatic_detection_languages(&languages)
-        // spawn the speech-dispatcher daemon before creating the client
-        // and trying to connect to the speech-dispatcher socket
+        .with_automatic_detection_languages(&english_or_russian)
         .with_spawn()?
         .build()?;
 
-    client
-        .set_client_name(ClientName::new("sasha", "example_app"))?
+    english_or_russian_client
+        .set_client_name(ClientName::new("joe", "example_app"))?
         .check_client_name_set()?
-        .speak()?
-        .check_receiving_data()?
         .send_lines_multilingual(&"Hello, my name is Joe. меня зовут джо".to_string())?;
 
-    client.quit()?.receive()?;
+    english_or_russian_client.quit()?.receive()?;
+
+    let english_or_spanish = vec![lingua::IsoCode639_1::EN, lingua::IsoCode639_1::ES];
+    let mut english_or_spanish_client = fifo::Builder::new()
+        // initialize the language detection model with a list of languages to distinguish between
+        .with_automatic_detection_languages(&english_or_spanish)
+        .with_spawn()?
+        .build()?;
+
+    english_or_spanish_client
+        .set_client_name(ClientName::new("joe", "example_app"))?
+        .check_client_name_set()?
+        .send_lines_multilingual(
+            &"Hello, my name is Joe. Me llamo Joe y yo hablo espanol".to_string(),
+        )?;
+
+    english_or_spanish_client.quit()?.receive()?;
+
     Ok(())
 }
 

--- a/ssip-client-async/examples/automatic_language_detection.rs
+++ b/ssip-client-async/examples/automatic_language_detection.rs
@@ -1,48 +1,27 @@
-#[cfg(all(unix, not(feature = "async-mio")))]
-use ssip_client_async::{fifo, ClientResult};
+use lingua::DetectionResult;
+use lingua::Language::{English, Spanish, Chinese};
+use lingua::LanguageDetectorBuilder;
 
-#[cfg(all(unix, not(feature = "async-mio")))]
-fn main() -> ClientResult<()> {
-    use ssip::ClientName;
-    let english_or_russian = vec![lingua::IsoCode639_1::EN, lingua::IsoCode639_1::RU];
-    let mut english_or_russian_client = fifo::Builder::new()
-        // initialize the language detection model with a list of languages to distinguish between
-        .with_automatic_detection_languages(&english_or_russian)
-        .with_spawn()?
-        .build()?;
-
-    english_or_russian_client
-        .set_client_name(ClientName::new("joe", "example_app"))?
-        .check_client_name_set()?
-        .send_lines_multilingual(&"Hello, my name is Joe. меня зовут джо".to_string())?;
-
-    english_or_russian_client.quit()?.receive()?;
-
-    let english_or_spanish = vec![lingua::IsoCode639_1::EN, lingua::IsoCode639_1::ES];
-    let mut english_or_spanish_client = fifo::Builder::new()
-        // initialize the language detection model with a list of languages to distinguish between
-        .with_automatic_detection_languages(&english_or_spanish)
-        .with_spawn()?
-        .build()?;
-
-    english_or_spanish_client
-        .set_client_name(ClientName::new("joe", "example_app"))?
-        .check_client_name_set()?
-        .send_lines_multilingual(
-            &"Hello, my name is Joe. Me llamo Joe y yo hablo espanol".to_string(),
-        )?;
-
-    english_or_spanish_client.quit()?.receive()?;
-
-    Ok(())
-}
-
-#[cfg(all(unix, feature = "async-mio"))]
 fn main() {
-    println!("see async_mio_loop for an example of asynchronous client.");
-}
+    let languages = vec![English, Chinese];
+    let detector = LanguageDetectorBuilder::from_languages(&languages).build();
+    let sentence = "Hello my name is Joe. 你好世界";
 
-#[cfg(not(unix))]
-fn main() {
-    println!("example only available on unix.");
+    let results: Vec<DetectionResult> = detector.detect_multiple_languages_of(sentence);
+    
+    println!("{:?}", results);
+
+    if let [first, second] = &results[..] {
+        assert_eq!(first.language(), English);
+        assert_eq!(
+            &sentence[first.start_index()..first.end_index()],
+            "Hello my name is Joe."
+        );
+
+        assert_eq!(second.language(), Spanish);
+        assert_eq!(
+            &sentence[second.start_index()..second.end_index()],
+            "你好世界"
+        );
+    } 
 }

--- a/ssip-client-async/src/client.rs
+++ b/ssip-client-async/src/client.rs
@@ -20,6 +20,7 @@ use crate::types::*;
 #[cfg(all(not(feature = "async-mio"), unix))]
 pub use std::os::unix::io::AsRawFd as Source;
 
+use lingua::LanguageDetector;
 #[cfg(feature = "async-mio")]
 pub use mio::event::Source;
 
@@ -69,13 +70,22 @@ macro_rules! send_range {
 pub struct Client<S: Read + Write + Source> {
     input: io::BufReader<S>,
     output: io::BufWriter<S>,
+    pub language_detector: Option<LanguageDetector>,
 }
 
 impl<S: Read + Write + Source> Client<S> {
     /// Create a SSIP client on the reader and writer.
-    pub(crate) fn new(input: io::BufReader<S>, output: io::BufWriter<S>) -> Self {
+    pub(crate) fn new(
+        input: io::BufReader<S>,
+        output: io::BufWriter<S>,
+        language_detector: Option<LanguageDetector>,
+    ) -> Self {
         // https://stackoverflow.com/questions/58467659/how-to-store-tcpstream-with-bufreader-and-bufwriter-in-a-data-structure
-        Self { input, output }
+        Self {
+            input,
+            output,
+            language_detector,
+        }
     }
 
     #[cfg(all(not(feature = "async-mio"), unix))]

--- a/ssip-client-async/src/fifo.rs
+++ b/ssip-client-async/src/fifo.rs
@@ -66,7 +66,7 @@ mod synchronous {
     pub struct Builder {
         path: FifoPath,
         mode: StreamMode,
-        pub language_detector_model: Option<lingua::LanguageDetector>,
+        pub languages_to_detect: Option<Vec<lingua::IsoCode639_1>>,
     }
 
     impl Builder {
@@ -74,7 +74,7 @@ mod synchronous {
             Self {
                 path: FifoPath::new(),
                 mode: StreamMode::Blocking,
-                language_detector_model: None,
+                languages_to_detect: None,
             }
         }
 
@@ -105,6 +105,17 @@ mod synchronous {
             Ok(self)
         }
 
+        fn init_language_detector(
+            languages: &Vec<lingua::IsoCode639_1>,
+        ) -> Option<lingua::LanguageDetector> {
+            Some(
+                lingua::LanguageDetectorBuilder::from_iso_codes_639_1(languages)
+                    // preload all language models into memory for faster client detection
+                    .with_preloaded_language_models()
+                    .build(),
+            )
+        }
+
         pub fn build(&self) -> io::Result<Client<UnixStream>> {
             let input = UnixStream::connect(self.path.get()?)?;
             match self.mode {
@@ -114,7 +125,21 @@ mod synchronous {
             }
 
             let output = input.try_clone()?;
-            Ok(Client::new(BufReader::new(input), BufWriter::new(output)))
+            match &self.languages_to_detect {
+                Some(languages) => {
+                    let language_detector = Self::init_language_detector(&languages).unwrap();
+                    Ok(Client::new(
+                        BufReader::new(input),
+                        BufWriter::new(output),
+                        Some(language_detector),
+                    ))
+                }
+                None => Ok(Client::new(
+                    BufReader::new(input),
+                    BufWriter::new(output),
+                    None,
+                )),
+            }
         }
     }
 }

--- a/ssip-client-async/src/fifo.rs
+++ b/ssip-client-async/src/fifo.rs
@@ -66,6 +66,7 @@ mod synchronous {
     pub struct Builder {
         path: FifoPath,
         mode: StreamMode,
+        pub language_detector_model: Option<lingua::LanguageDetector>
     }
 
     impl Builder {
@@ -73,6 +74,7 @@ mod synchronous {
             Self {
                 path: FifoPath::new(),
                 mode: StreamMode::Blocking,
+                language_detector_model: None
             }
         }
 
@@ -102,7 +104,7 @@ mod synchronous {
                 .output()?;
             Ok(self)
         }
-
+ 
         pub fn build(&self) -> io::Result<Client<UnixStream>> {
             let input = UnixStream::connect(self.path.get()?)?;
             match self.mode {

--- a/ssip-client-async/src/fifo.rs
+++ b/ssip-client-async/src/fifo.rs
@@ -66,7 +66,7 @@ mod synchronous {
     pub struct Builder {
         path: FifoPath,
         mode: StreamMode,
-        pub language_detector_model: Option<lingua::LanguageDetector>
+        pub language_detector_model: Option<lingua::LanguageDetector>,
     }
 
     impl Builder {
@@ -74,7 +74,7 @@ mod synchronous {
             Self {
                 path: FifoPath::new(),
                 mode: StreamMode::Blocking,
-                language_detector_model: None
+                language_detector_model: None,
             }
         }
 
@@ -104,7 +104,7 @@ mod synchronous {
                 .output()?;
             Ok(self)
         }
- 
+
         pub fn build(&self) -> io::Result<Client<UnixStream>> {
             let input = UnixStream::connect(self.path.get()?)?;
             match self.mode {

--- a/ssip-client-async/src/language_detection.rs
+++ b/ssip-client-async/src/language_detection.rs
@@ -22,11 +22,8 @@ impl Builder {
 }
 
 impl<S: Read + Write + Source> Client<S> {
-
-
     /// A wrapper over the `send_lines` method to send lines in multiple languages
     pub fn send_lines_multilingual(&mut self, lines: &[String]) -> ClientResult<()> {
-
         Ok(())
     }
 }

--- a/ssip-client-async/src/language_detection.rs
+++ b/ssip-client-async/src/language_detection.rs
@@ -1,0 +1,32 @@
+use std::io::{Read, Write};
+// Trick to have common implementation for std and mio streams..
+#[cfg(all(not(feature = "async-mio"), unix))]
+pub use std::os::unix::io::AsRawFd as Source;
+
+use crate::{fifo::Builder, Client};
+use lingua::IsoCode639_3;
+use ssip::ClientResult;
+
+impl Builder {
+    /// Initialize the language detection model with a list of languages to distinguish between
+    /// Use the ISO 639-3 language codes to distinguish between languages
+    pub fn with_language_detection(&mut self, languages: &Vec<IsoCode639_3>) -> &mut Self {
+        self.language_detector_model = Some(
+            lingua::LanguageDetectorBuilder::from_iso_codes_639_3(languages)
+                // preload all language models into memory for faster client detection
+                .with_preloaded_language_models()
+                .build(),
+        );
+        self
+    }
+}
+
+impl<S: Read + Write + Source> Client<S> {
+
+
+    /// A wrapper over the `send_lines` method to send lines in multiple languages
+    pub fn send_lines_multilingual(&mut self, lines: &[String]) -> ClientResult<()> {
+
+        Ok(())
+    }
+}

--- a/ssip-client-async/src/language_detection.rs
+++ b/ssip-client-async/src/language_detection.rs
@@ -34,7 +34,8 @@ impl<S: Read + Write + Source> Client<S> {
         for result in detection_results {
             let language_code = result.language().iso_code_639_1().to_string();
             // the status check stalls for some reason and never returns
-            self.set_language(ssip::ClientScope::Current, &language_code)?.check_status(OK_LANGUAGE_SET)?;
+            self.set_language(ssip::ClientScope::Current, &language_code)?
+                .check_status(OK_LANGUAGE_SET)?;
             let subsection = lines[result.start_index()..result.end_index()].to_string();
             self.send_lines(&[subsection])?.receive()?;
         }

--- a/ssip-client-async/src/language_detection.rs
+++ b/ssip-client-async/src/language_detection.rs
@@ -3,27 +3,42 @@ use std::io::{Read, Write};
 #[cfg(all(not(feature = "async-mio"), unix))]
 pub use std::os::unix::io::AsRawFd as Source;
 
-use crate::{fifo::Builder, Client};
-use lingua::IsoCode639_3;
-use ssip::ClientResult;
+use crate::{fifo::Builder, Client, OK_LANGUAGE_SET};
+use lingua::IsoCode639_1;
+use ssip::{ClientError, ClientResult};
 
 impl Builder {
     /// Initialize the language detection model with a list of languages to distinguish between
     /// Use the ISO 639-3 language codes to distinguish between languages
-    pub fn with_language_detection(&mut self, languages: &Vec<IsoCode639_3>) -> &mut Self {
-        self.language_detector_model = Some(
-            lingua::LanguageDetectorBuilder::from_iso_codes_639_3(languages)
-                // preload all language models into memory for faster client detection
-                .with_preloaded_language_models()
-                .build(),
-        );
+    pub fn with_automatic_detection_languages(
+        &mut self,
+        languages: &Vec<IsoCode639_1>,
+    ) -> &mut Self {
+        self.languages_to_detect = Some(languages.clone());
         self
     }
 }
 
 impl<S: Read + Write + Source> Client<S> {
     /// A wrapper over the `send_lines` method to send lines in multiple languages
-    pub fn send_lines_multilingual(&mut self, lines: &[String]) -> ClientResult<()> {
-        Ok(())
+    pub fn send_lines_multilingual(&mut self, lines: &String) -> ClientResult<&mut Self> {
+        let detector =
+            self.language_detector
+                .as_ref()
+                .ok_or(ClientError::LanguageDetectionError(
+                    "Language detection not initialized".to_string(),
+                ))?;
+
+        let detection_results = detector.detect_multiple_languages_of(lines);
+
+        for result in detection_results {
+            let language_code = result.language().iso_code_639_1().to_string();
+            // the status check stalls for some reason and never returns
+            self.set_language(ssip::ClientScope::Current, &language_code)?.check_status(OK_LANGUAGE_SET)?;
+            let subsection = lines[result.start_index()..result.end_index()].to_string();
+            self.send_lines(&[subsection])?.receive()?;
+        }
+
+        Ok(self)
     }
 }

--- a/ssip-client-async/src/language_detection.rs
+++ b/ssip-client-async/src/language_detection.rs
@@ -20,7 +20,7 @@ impl Builder {
 }
 
 impl<S: Read + Write + Source> Client<S> {
-    /// A wrapper over the `send_lines` method to send lines in multiple languages
+    /// A wrapper over the `send_lines` method to send lines in multiple languages. Uses whatever languages were set when the client was built
     pub fn send_lines_multilingual(&mut self, lines: &String) -> ClientResult<&mut Self> {
         let detector =
             self.language_detector
@@ -37,7 +37,10 @@ impl<S: Read + Write + Source> Client<S> {
             self.set_language(ssip::ClientScope::Current, &language_code)?
                 .check_status(OK_LANGUAGE_SET)?;
             let subsection = lines[result.start_index()..result.end_index()].to_string();
-            self.send_lines(&[subsection])?.receive()?;
+            self.speak()?
+                .check_receiving_data()?
+                .send_lines(&[subsection])?
+                .receive()?;
         }
 
         Ok(self)

--- a/ssip-client-async/src/lib.rs
+++ b/ssip-client-async/src/lib.rs
@@ -38,6 +38,7 @@ pub mod constants;
 pub mod fifo;
 pub mod net;
 pub mod tcp;
+pub mod language_detection;
 
 #[cfg(any(not(feature = "async-mio"), doc))]
 pub use client::Client;

--- a/ssip-client-async/src/lib.rs
+++ b/ssip-client-async/src/lib.rs
@@ -36,9 +36,9 @@ pub mod client;
 pub mod constants;
 #[cfg(unix)]
 pub mod fifo;
+pub mod language_detection;
 pub mod net;
 pub mod tcp;
-pub mod language_detection;
 
 #[cfg(any(not(feature = "async-mio"), doc))]
 pub use client::Client;

--- a/ssip-client-async/src/tcp.rs
+++ b/ssip-client-async/src/tcp.rs
@@ -58,7 +58,11 @@ mod synchronous {
                 StreamMode::TimeOut(timeout) => input.set_read_timeout(Some(timeout))?,
             }
             let output = input.try_clone()?;
-            Ok(Client::new(BufReader::new(input), BufWriter::new(output)))
+            Ok(Client::new(
+                BufReader::new(input),
+                BufWriter::new(output),
+                None,
+            ))
         }
     }
 }

--- a/ssip/src/lib.rs
+++ b/ssip/src/lib.rs
@@ -417,6 +417,8 @@ pub enum ClientError {
     TooManyLines,
     #[error("Unexpected status: {0}")]
     UnexpectedStatus(ReturnCode),
+    #[error("Failure automatically detecting language: {0}")]
+    LanguageDetectionError(String),
 }
 
 impl ClientError {


### PR DESCRIPTION
- [x] Create a `with_language_detection` method on the fifo builder to greedily initialize the language detection models
- [x] Create a `send_lines_multilingual` method (still playing with names for this) to automatically send lines while also setting the proper language.
- [ ] Put all language detection features under a feature flag
- [ ] Add tests
- [ ] Fix clippy and any formatting issues before review
