### PR TITLE
Fix examples path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ let msg_id = client.speak()?.send_line("hello")?.receive_message_id()?;
 client.quit()?;
 ```
 
-See [other examples](https://github.com/odilia-app/ssip-client-async/tree/main/examples) in the repository.
+See [other examples](./ssip-client-async/examples) in the repository.
 
 License
 -------


### PR DESCRIPTION
Previous path in the readme was an absolute URL and thus broke when the examples were moved